### PR TITLE
Separate executable resolution from build skipping

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   MARLIM3_SKIP_BUILD: "1"
+  MARLIM3_SKIP_EXECUTABLE_RESOLUTION: "1"
   ARTIFACT_RETENTION_DAYS: "7"
 
 jobs:
@@ -586,6 +587,8 @@ jobs:
           - windows-2022
           - macos-14
     runs-on: ${{ matrix.os }}
+    env:
+      MARLIM3_SKIP_EXECUTABLE_RESOLUTION: "0"
 
     steps:
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ See [Compilation](#compilation) below. After building, copy `build/Marlim3` to `
 MARLIM3_SKIP_BUILD=1 uv sync --locked
 ```
 
+`MARLIM3_SKIP_BUILD=1` skips local CMake compilation. Set `MARLIM3_SKIP_EXECUTABLE_RESOLUTION=1` only when an import must not resolve or download the executable.
+
 ## Usage
 
 ### Option 1: Python Package
@@ -176,6 +178,8 @@ Then activate the package locally (skipping recompilation):
 ```bash
 MARLIM3_SKIP_BUILD=1 uv sync --locked
 ```
+
+`MARLIM3_SKIP_BUILD=1` skips local CMake compilation; installed packages can still download the release executable on import.
 
 ### Run tests
 

--- a/marlim3/__init__.py
+++ b/marlim3/__init__.py
@@ -3,7 +3,7 @@ Marlim3 - Simulacao de escoamento multifasico permanente e transiente.
 """
 
 # Import version from root _version.py
-import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 # Try to import from root _version.py (for development)
@@ -12,10 +12,8 @@ try:
     if (_root_dir / '_version.py').exists():
         exec(open(_root_dir / '_version.py').read())
     else:
-        # Fallback for installed package
-        __version__ = '3.3.0'
-except:
-    # Fallback
+        __version__ = version("marlim3")
+except PackageNotFoundError:
     __version__ = '3.3.0'
 
 # Ensure executable is downloaded on first import

--- a/marlim3/_download.py
+++ b/marlim3/_download.py
@@ -11,6 +11,11 @@ import platform
 import urllib.request
 from pathlib import Path
 
+
+def _env_flag(name):
+    return os.environ.get(name, "").strip().lower() not in {"", "0", "false", "no", "off"}
+
+
 def get_platform_asset_info():
     """Determine which asset to download based on the platform.
     
@@ -155,6 +160,9 @@ def _try_build_from_source():
     import subprocess
     import shutil
 
+    if _env_flag('MARLIM3_SKIP_BUILD'):
+        return False
+
     package_dir = Path(__file__).parent
     root_dir = package_dir.parent
 
@@ -207,8 +215,7 @@ def ensure_executable():
     
     This is called automatically on package import.
     """
-    # Skip if user wants to skip
-    if os.environ.get('MARLIM3_SKIP_BUILD'):
+    if _env_flag('MARLIM3_SKIP_EXECUTABLE_RESOLUTION'):
         return
     
     # Check if executable exists and works

--- a/marlim3/_rede/_rede.py
+++ b/marlim3/_rede/_rede.py
@@ -1,8 +1,9 @@
-import importlib.resources as pkg_resources
 import os
 import numpy as np
 import json 
 import shutil
+from contextlib import nullcontext
+from .._download import get_executable_path
 from .._plots._plots_perfis import _plotar_perfis, _plotar_perfis_animados
 from .._plots._plots_redes import _plotar_rede
 from .._tramo._tramo import Tramo
@@ -130,17 +131,10 @@ class Rede:
                 tracker=None,
                 sanitized=False):
         
-        # Verificar o sistema operacional
-        if platform.system() == 'Windows':
-            executavel_name = 'Marlim3.exe'
-        else:
-            executavel_name = 'Marlim3'
-        
         if label != 'marlim3_rede':
             self.label = label
 
-        with pkg_resources.as_file(
-                pkg_resources.files('marlim3').joinpath(executavel_name)) as executavel:
+        with nullcontext(get_executable_path()) as executavel:
 
             filename = label+'.json'
 

--- a/marlim3/_tramo/_tramo.py
+++ b/marlim3/_tramo/_tramo.py
@@ -1,9 +1,10 @@
-import importlib.resources as pkg_resources
 import pandas as pd
 import json
 import os
 import shutil
 import requests
+from contextlib import nullcontext
+from .._download import get_executable_path
 from .._conversores._conversor_marlim3_tplppl import convert_to_ppl_tpl
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
@@ -282,17 +283,10 @@ class Tramo:
                 tracker=None,
                 sanitized=False):
         
-        # Verificar o sistema operacional
-        if platform.system() == 'Windows':
-            executavel_name = 'Marlim3.exe'
-        else:
-            executavel_name = 'Marlim3'
-
         if label != 'marlim3_model':
             self.label = label
 
-        with pkg_resources.as_file(
-                pkg_resources.files('marlim3').joinpath(executavel_name)) as executavel:
+        with nullcontext(get_executable_path()) as executavel:
 
             filename = label+'.json'
             

--- a/tests/test_configure_simulation.py
+++ b/tests/test_configure_simulation.py
@@ -9,15 +9,14 @@ Execução:
 """
 
 import copy
-import importlib.resources as pkg_resources
 import os
-import platform
 
 import numpy as np
 import pandas as pd
 import pytest
 
 import marlim3
+from marlim3._download import executable_exists
 
 
 # ============================================================================
@@ -25,21 +24,12 @@ import marlim3
 # ============================================================================
 
 def _executavel_disponivel():
-    exe_name = "marlim3.exe" if platform.system() == "Windows" else "marlim3"
-    for name in [exe_name, "Marlim3.exe" if platform.system() == "Windows" else "Marlim3"]:
-        try:
-            ref = pkg_resources.files("marlim3").joinpath(name)
-            with pkg_resources.as_file(ref) as p:
-                if p.exists():
-                    return True
-        except (FileNotFoundError, AttributeError, TypeError):
-            continue
-    return False
+    return executable_exists()
 
 
 skip_sem_executavel = pytest.mark.skipif(
     not _executavel_disponivel(),
-    reason="Executável Marlim3 não encontrado no pacote",
+    reason="Executável Marlim3 não encontrado",
 )
 
 

--- a/tests/test_demos_steady_state.py
+++ b/tests/test_demos_steady_state.py
@@ -8,36 +8,26 @@ Execução:
     pytest tests/test_demos.py -v -m simulacao
 """
 
-import importlib.resources as pkg_resources
 import os
-import platform
 import shutil
 
 import pandas as pd
 import pytest
 
 import marlim3
+from marlim3._download import executable_exists
 
 # ============================================================================
 # Verificação do executável
 # ============================================================================
 
 def _executavel_disponivel():
-    exe_name = "marlim3.exe" if platform.system() == "Windows" else "marlim3"
-    for name in [exe_name, "Marlim3.exe" if platform.system() == "Windows" else "Marlim3"]:
-        try:
-            ref = pkg_resources.files("marlim3").joinpath(name)
-            with pkg_resources.as_file(ref) as p:
-                if p.exists():
-                    return True
-        except (FileNotFoundError, AttributeError, TypeError):
-            continue
-    return False
+    return executable_exists()
 
 
 skip_sem_executavel = pytest.mark.skipif(
     not _executavel_disponivel(),
-    reason="Executável Marlim3 não encontrado no pacote",
+    reason="Executável Marlim3 não encontrado",
 )
 
 # ============================================================================

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -9,9 +9,7 @@ Execução:
     pytest tests/test_regression.py -v -m regressao
 """
 
-import importlib.resources as pkg_resources
 import os
-import platform
 import shutil
 
 import numpy as np
@@ -19,27 +17,19 @@ import pandas as pd
 import pytest
 
 import marlim3
+from marlim3._download import executable_exists
 
 # ============================================================================
 # Verificação do executável
 # ============================================================================
 
 def _executavel_disponivel():
-    exe_name = "marlim3.exe" if platform.system() == "Windows" else "marlim3"
-    for name in [exe_name, "Marlim3.exe" if platform.system() == "Windows" else "Marlim3"]:
-        try:
-            ref = pkg_resources.files("marlim3").joinpath(name)
-            with pkg_resources.as_file(ref) as p:
-                if p.exists():
-                    return True
-        except (FileNotFoundError, AttributeError, TypeError):
-            continue
-    return False
+    return executable_exists()
 
 
 skip_sem_executavel = pytest.mark.skipif(
     not _executavel_disponivel(),
-    reason="Executável Marlim3 não encontrado no pacote",
+    reason="Executável Marlim3 não encontrado",
 )
 
 # ============================================================================


### PR DESCRIPTION
- Add MARLIM3_SKIP_EXECUTABLE_RESOLUTION so CI can skip import-time executable resolution without changing MARLIM3_SKIP_BUILD semantics.
- Read installed package versions from wheel metadata so release asset downloads target the matching GitHub tag.
- Centralize simulator executable lookup so local runs use either the packaged executable or the build/ fallback.