### PR TITLE
Fix Windows batch access violation during Marlim3 cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ celerybeat-schedule
 .spyderproject
 .spyproject
 .ropeproject
+marlim-batch-mr2/
 
 # Logs, temporarios e backup
 *.log

--- a/_version.py
+++ b/_version.py
@@ -1,3 +1,3 @@
 """Version information for Marlim3 package."""
 
-__version__ = '3.6.3'
+__version__ = '3.6.4'

--- a/src/core/Leitura.cpp
+++ b/src/core/Leitura.cpp
@@ -1100,16 +1100,15 @@ Ler& Ler::operator =(const Ler& vler) {
 	       	delete [] Tempsonico;
 	    }
 
-		if(nfluP>0){
+		if(tabVisc!=0){
 			for(int i=0; i<nfluP;i++){
-				if(flup[i].corrOM==7){
-					if(tabVisc[i].parserie>0){
-						delete [] tabVisc[i].visc;
-						delete [] tabVisc[i].temp;
-					}
-					delete [] tabVisc;
+				if(tabVisc[i].parserie>0){
+					delete [] tabVisc[i].visc;
+					delete [] tabVisc[i].temp;
 				}
 			}
+			delete [] tabVisc;
+			tabVisc=0;
 		}
 
 		if(nsegrega>0){
@@ -1627,16 +1626,15 @@ void Ler::copiaSemJson(Ler& vler) {
 	       	delete [] Tempsonico;
 	    }
 
-		if(nfluP>0){
+		if(tabVisc!=0){
 			for(int i=0; i<nfluP;i++){
-				if(flup[i].corrOM==7){
-					if(tabVisc[i].parserie>0){
-						delete [] tabVisc[i].visc;
-						delete [] tabVisc[i].temp;
-					}
-					delete [] tabVisc;
+				if(tabVisc[i].parserie>0){
+					delete [] tabVisc[i].visc;
+					delete [] tabVisc[i].temp;
 				}
 			}
+			delete [] tabVisc;
+			tabVisc=0;
 		}
 
 		if(nsegrega>0){
@@ -5273,9 +5271,9 @@ void Ler::parse_fluidos_producao(
 							        &iier);
 							 for(int k=0;k<npseudo;k++)flup[i].fracMol[k]=oGORAdjustedGlobalComp[k];
 							 flup[i].atualizaPropCompStandard();
-					         delete GivenInitialLiqComposition;
-					         delete GivenInitialVapComposition;
-					         delete oGORAdjustedGlobalComp;
+					         delete[] GivenInitialLiqComposition;
+					         delete[] GivenInitialVapComposition;
+					         delete[] oGORAdjustedGlobalComp;
 						}
 					}
 

--- a/src/core/LerAS.cpp
+++ b/src/core/LerAS.cpp
@@ -3357,9 +3357,9 @@ void ASens::atualizaCompRGO(double rgo, ProFlu& flui){
 	        &iier);
 	 for(int k=0;k<npseudo;k++)flui.fracMol[k]=oGORAdjustedGlobalComp[k];
 	 flui.atualizaPropCompStandard();
-     delete GivenInitialLiqComposition;
-     delete GivenInitialVapComposition;
-     delete oGORAdjustedGlobalComp;
+     delete[] GivenInitialLiqComposition;
+     delete[] GivenInitialVapComposition;
+     delete[] oGORAdjustedGlobalComp;
 
 }
 

--- a/src/core/PropFlu.cpp
+++ b/src/core/PropFlu.cpp
@@ -1829,9 +1829,9 @@ ProFlu& ProFlu::operator =(const ProFlu& fluido){//alteracao2
  }
 
  if(flashCompleto==2 || fluido.npseudo>0){
-	 if(npseudo>0)delete fracMol;
-	 if(npseudo>0)delete oCalculatedLiqComposition;
-	 if(npseudo>0)delete oCalculatedVapComposition;
+	 if(npseudo>0)delete[] fracMol;
+	 if(npseudo>0)delete[] oCalculatedLiqComposition;
+	 if(npseudo>0)delete[] oCalculatedVapComposition;
 	 npseudo=fluido.npseudo;
 	 fracMol=new double[npseudo];
 	 oCalculatedLiqComposition=new double[npseudo];
@@ -6688,4 +6688,3 @@ ostream& operator<<(ostream& s, const ProFlu& flui){
 }
 
 //template class ProFlu;
-

--- a/src/core/SisProd.cpp
+++ b/src/core/SisProd.cpp
@@ -2618,7 +2618,7 @@ void SProd::montasistema(double* compfonte,int* posicfonte, int nfontes) {
 
          resettrendtrans[i] = 0;
          ntrendtrans[i] = 0;
-         ntrendtransB = new int[arq.ntendtransp];
+         ntrendtransB[i] = 0;
        }
 
      }
@@ -34722,4 +34722,3 @@ double SProd::buscaTramoSecVazPerm(double pPartida, int indPartida) {
 }
 
 //template class SProd;
-

--- a/src/include/Leitura.h
+++ b/src/include/Leitura.h
@@ -2019,13 +2019,11 @@ class Ler{
        	  delete [] Tempsonico;
        }
 
-		if(nfluP>0){
+		if(tabVisc!=0){
 			for(int i=0; i<nfluP;i++){
-				if(flup[i].corrOM==7){
-					if(tabVisc[i].parserie>0){
-						delete [] tabVisc[i].visc;
-						delete [] tabVisc[i].temp;
-					}
+				if(tabVisc[i].parserie>0){
+					delete [] tabVisc[i].visc;
+					delete [] tabVisc[i].temp;
 				}
 			}
 			delete [] tabVisc;

--- a/src/include/PropFlu.h
+++ b/src/include/PropFlu.h
@@ -769,8 +769,8 @@ class ProFlu{
      	   RGO=tempRGO;
      	   if(dStockTankVaporMassFraction>0 && RGO<1e-15)RGO=1e6;
      	   IRGO=RGO*35.31467/6.29;
-     	   if(nuloL==1)delete GivenInitialLiqComposition;
-     	   if(nuloV==1)delete GivenInitialVapComposition;
+     	   if(nuloL==1)delete[] GivenInitialLiqComposition;
+     	   if(nuloV==1)delete[] GivenInitialVapComposition;
        }
 
         void atualizaPropComp(double pres, double temp,double GivenInitialBeta=-1.0,
@@ -846,8 +846,8 @@ class ProFlu{
 
         		}
         	}
-        	if(nuloL==1)delete GivenInitialLiqComposition;
-        	if(nuloV==1)delete GivenInitialVapComposition;
+        	if(nuloL==1)delete[] GivenInitialLiqComposition;
+        	if(nuloV==1)delete[] GivenInitialVapComposition;
 
         }
 
@@ -877,4 +877,3 @@ ostream& operator<<(ostream& s, const ProFlu&);//saida de valores de propriedade
 
 
 #endif
-

--- a/src/include/SisProd.h
+++ b/src/include/SisProd.h
@@ -629,11 +629,12 @@ class SProd {
     if(arq.nperfistransg>0 && arq.lingas>0) delete [] ncelperftransg;
 
    if(arq.ntendp>0 && redeTemporario==0) {
-      for(int i=0;i<arq.ntendp;i++) {
-        for(int j=0; j<TrendLengthP[i]; j++) //if(MatTrendP[i][j]) delete [] MatTrendP[i][j];
-        	if(MatTrendP)delete [] MatTrendP[i][j];
-        //if(MatTrendP[i])delete [] MatTrendP[i];
-        if(MatTrendP)delete [] MatTrendP[i];
+      for(int i=0;i<arq.ntendp && MatTrendP && TrendLengthP;i++) {
+        if(MatTrendP[i]) {
+          for(int j=0; j<TrendLengthP[i]; j++)
+            delete [] MatTrendP[i][j];
+          delete [] MatTrendP[i];
+        }
       }
       //if(MatTrendP)delete [] MatTrendP;
       if(MatTrendP)delete [] MatTrendP;
@@ -647,11 +648,12 @@ class SProd {
     }
 
     if(arq.ntendg>0 && arq.lingas>0 && redeTemporario==0) {
-      for(int i=0;i<arq.ntendg;i++) {
-        for(int j=0; j<TrendLengthG[i]; j++) //if(MatTrendG[i][j]) delete [] MatTrendG[i][j];
-        	if(MatTrendG)delete [] MatTrendG[i][j];
-             //if(MatTrendG[i])delete [] MatTrendG[i];
-            if(MatTrendG)delete [] MatTrendG[i];
+      for(int i=0;i<arq.ntendg && MatTrendG && TrendLengthG;i++) {
+        if(MatTrendG[i]) {
+          for(int j=0; j<TrendLengthG[i]; j++)
+            delete [] MatTrendG[i][j];
+          delete [] MatTrendG[i];
+        }
       }
       //if(MatTrendG)delete [] MatTrendG;
       if(MatTrendG)delete [] MatTrendG;
@@ -664,12 +666,12 @@ class SProd {
       if(ntrendgB)delete [] ntrendgB;
     }
     if(arq.ntendtransp>0 && redeTemporario==0) {
-      for(int i=0;i<arq.ntendtransp;i++) {
-        for(int j=0; j<TrendLengthTransP[i]; j++)
-        //if(MatTrendTransP[i][j]) delete [] MatTrendTransP[i][j];
-        //if(MatTrendTransP[i])delete [] MatTrendTransP[i];
-        	if(MatTrendTransP)delete [] MatTrendTransP[i][j];
-            if(MatTrendTransP)delete [] MatTrendTransP[i];
+      for(int i=0;i<arq.ntendtransp && MatTrendTransP && TrendLengthTransP;i++) {
+        if(MatTrendTransP[i]) {
+          for(int j=0; j<TrendLengthTransP[i]; j++)
+            delete [] MatTrendTransP[i][j];
+          delete [] MatTrendTransP[i];
+        }
       }
       //if(MatTrendTransP)delete [] MatTrendTransP;
       if(MatTrendTransP)delete [] MatTrendTransP;
@@ -683,12 +685,12 @@ class SProd {
     }
 
     if(arq.ntendtransg>0 && redeTemporario==0) {
-      for(int i=0;i<arq.ntendtransg;i++) {
-        for(int j=0; j<TrendLengthTransG[i]; j++)
-        //if(MatTrendTransP[i][j]) delete [] MatTrendTransP[i][j];
-        //if(MatTrendTransP[i])delete [] MatTrendTransP[i];
-        	if(MatTrendTransG)delete [] MatTrendTransG[i][j];
-            if(MatTrendTransG)delete [] MatTrendTransG[i];
+      for(int i=0;i<arq.ntendtransg && MatTrendTransG && TrendLengthTransG;i++) {
+        if(MatTrendTransG[i]) {
+          for(int j=0; j<TrendLengthTransG[i]; j++)
+            delete [] MatTrendTransG[i][j];
+          delete [] MatTrendTransG[i];
+        }
       }
       //if(MatTrendTransP)delete [] MatTrendTransP;
       if(MatTrendTransG)delete [] MatTrendTransG;


### PR DESCRIPTION
This PR fixes Windows-specific crashes observed during Marlim3 batch execution, where some simulations failed with native process return errors such as `Marlim3.exe returned code 3221225477`. 

The root cause was undefined behavior in native cleanup paths that Linux tolerated in these cases, but Windows exposed as access violations.

This PR also bumps the release version to `v3.6.4` and adds the local batch script/output path to `.gitignore`.

## Changes

* Fix cleanup logic to avoid reading `flup` after it has already been released.
* Use `delete[]` for arrays allocated with `new[]`.
* Initialize `ntrendtransB` entries correctly instead of reallocating the pointer inside a loop.
* Make trend matrix destruction more defensive.
* Bump package/release version to `3.6.4`.
* Add local batch execution artifacts/scripts to `.gitignore`.

## Validation

* Re-ran the Windows batch validation.
* Confirmed that `Marlim3.exe returned code 3221225477` no longer appears.
* Compared Windows and Linux batch logs after the fix.
* Both platforms now report the same overall result.