### PR TITLE
Statically link GNU runtimes in macOS ARM release binary

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -229,15 +229,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf build
-          BREW_PREFIX=$(brew --prefix)
-          GCC_VERSION=$(ls "${BREW_PREFIX}"/bin/gcc-[0-9]* 2>/dev/null | grep -oE 'gcc-[0-9]+$' | grep -oE '[0-9]+' | sort -n | tail -1)
-          if [ -z "$GCC_VERSION" ]; then
-            echo "No Homebrew GCC version found"
-            exit 1
-          fi
-          cmake --preset gcc-release \
-            -DCMAKE_CXX_COMPILER="g++-${GCC_VERSION}" \
-            -DCMAKE_Fortran_COMPILER="gfortran-${GCC_VERSION}"
+          cmake --preset gcc-release
           cmake --build --preset gcc-release -j$(sysctl -n hw.ncpu)
 
       - name: Inspect executable
@@ -246,7 +238,10 @@ jobs:
           test -x build/Marlim3
           file build/Marlim3
           lipo -info build/Marlim3
-          otool -L build/Marlim3
+          otool -L build/Marlim3 | tee build/Marlim3.otool
+          otool -l build/Marlim3 | tee build/Marlim3.load-commands
+          ! grep -E '/opt/homebrew|libgomp|libgfortran|libquadmath|libstdc\+\+' build/Marlim3.otool
+          ! grep -E 'LC_RPATH|/opt/homebrew|libgomp|libgfortran|libquadmath|libstdc\+\+' build/Marlim3.load-commands
           ./build/Marlim3 --help >/dev/null
 
       - name: Compute SHA-256 of executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,25 @@
 cmake_minimum_required(VERSION 3.16)
 
+if(APPLE AND (NOT CMAKE_CXX_COMPILER OR CMAKE_CXX_COMPILER STREQUAL "g++"))
+    find_program(_marlim_cxx NAMES g++-16 g++-15 g++-14 g++-13 g++-12
+        HINTS /opt/homebrew/bin /usr/local/bin)
+    if(NOT _marlim_cxx)
+        message(FATAL_ERROR "No Homebrew GCC found on macOS. Run: brew install gcc")
+    endif()
+    set(CMAKE_CXX_COMPILER "${_marlim_cxx}" CACHE FILEPATH "C++ compiler" FORCE)
+    unset(_marlim_cxx)
+endif()
+
+if(APPLE AND (NOT CMAKE_Fortran_COMPILER OR CMAKE_Fortran_COMPILER STREQUAL "gfortran"))
+    find_program(_marlim_fc NAMES gfortran-16 gfortran-15 gfortran-14 gfortran-13 gfortran-12
+        HINTS /opt/homebrew/bin /usr/local/bin)
+    if(NOT _marlim_fc)
+        message(FATAL_ERROR "No Homebrew gfortran found on macOS. Run: brew install gcc")
+    endif()
+    set(CMAKE_Fortran_COMPILER "${_marlim_fc}" CACHE FILEPATH "Fortran compiler" FORCE)
+    unset(_marlim_fc)
+endif()
+
 # Version: single source of truth is _version.py; re-configure when it changes.
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/_version.py")
 file(READ "${CMAKE_SOURCE_DIR}/_version.py" _version_py_contents)
@@ -14,6 +34,7 @@ project(Marlim3 VERSION ${MARLIM3_VERSION} LANGUAGES CXX Fortran)
 option(MARLIM_STATIC_GNU_RUNTIMES "Prefer static GNU runtimes where supported" ON)
 option(MARLIM_MINGW_STATIC "Build a fully static executable with MinGW" ON)
 set(MARLIM_FORTRAN_LIBS "" CACHE STRING "Additional Fortran runtime libraries to link explicitly")
+set(MARLIM_GCC_STATIC_LIB_DIR "" CACHE PATH "Directory containing static GNU runtime libraries for macOS builds")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -60,13 +81,30 @@ set(F90_SOURCES
 )
 
 # Remove implicit dynamic Fortran runtimes before target creation to preserve static links.
-if(MARLIM_STATIC_GNU_RUNTIMES AND UNIX AND NOT APPLE
+if(MARLIM_STATIC_GNU_RUNTIMES
         AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
         AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    set(MARLIM_LINUX_STATIC_RUNTIMES ON)
-    list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES gfortran quadmath)
+    if(UNIX AND NOT APPLE)
+        set(MARLIM_LINUX_STATIC_RUNTIMES ON)
+        set(MARLIM_MACOS_STATIC_RUNTIMES OFF)
+        list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES gfortran quadmath)
+    elseif(APPLE)
+        set(MARLIM_LINUX_STATIC_RUNTIMES OFF)
+        set(MARLIM_MACOS_STATIC_RUNTIMES ON)
+        list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES gfortran quadmath)
+    else()
+        set(MARLIM_LINUX_STATIC_RUNTIMES OFF)
+        set(MARLIM_MACOS_STATIC_RUNTIMES OFF)
+    endif()
 else()
     set(MARLIM_LINUX_STATIC_RUNTIMES OFF)
+    set(MARLIM_MACOS_STATIC_RUNTIMES OFF)
+endif()
+
+if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    message(FATAL_ERROR
+        "macOS portable builds require GNU g++/gfortran. "
+        "Set CXX=g++-<version> and FC=gfortran-<version> before configuring.")
 endif()
 
 add_executable(Marlim3 ${CXX_SOURCES} ${F90_SOURCES})
@@ -98,7 +136,7 @@ else()
 endif()
 
 find_package(OpenMP REQUIRED COMPONENTS CXX)
-if(MARLIM_LINUX_STATIC_RUNTIMES OR MARLIM_MINGW_STATIC_RUNTIMES)
+if(MARLIM_LINUX_STATIC_RUNTIMES OR MARLIM_MACOS_STATIC_RUNTIMES OR MARLIM_MINGW_STATIC_RUNTIMES)
     # Static-runtime paths use compile-only OpenMP; libgomp is linked explicitly below.
     target_compile_options(Marlim3 PRIVATE -fopenmp)
 else()
@@ -112,6 +150,58 @@ if(MARLIM_LINUX_STATIC_RUNTIMES)
     target_link_libraries(Marlim3 PRIVATE
         -Wl,-Bstatic gfortran quadmath gomp -Wl,-Bdynamic
         -Wl,--push-state,-Bdynamic pthread dl -Wl,--pop-state)
+
+elseif(MARLIM_MACOS_STATIC_RUNTIMES)
+    function(marlim_find_gcc_static_library output_var library_name)
+        if(MARLIM_GCC_STATIC_LIB_DIR)
+            set(_candidate "${MARLIM_GCC_STATIC_LIB_DIR}/${library_name}")
+        else()
+            execute_process(
+                COMMAND "${CMAKE_CXX_COMPILER}" "-print-file-name=${library_name}"
+                OUTPUT_VARIABLE _candidate
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+        endif()
+
+        if(NOT IS_ABSOLUTE "${_candidate}" OR NOT EXISTS "${_candidate}")
+            message(FATAL_ERROR
+                "Could not find static GNU runtime ${library_name}. "
+                "Set MARLIM_GCC_STATIC_LIB_DIR to the directory containing GCC .a libraries.")
+        endif()
+
+        set(${output_var} "${_candidate}" PARENT_SCOPE)
+    endfunction()
+
+    marlim_find_gcc_static_library(MARLIM_LIBGOMP_STATIC libgomp.a)
+    marlim_find_gcc_static_library(MARLIM_LIBGFORTRAN_STATIC libgfortran.a)
+    marlim_find_gcc_static_library(MARLIM_LIBQUADMATH_STATIC libquadmath.a)
+    get_filename_component(MARLIM_LIBGOMP_STATIC_REAL "${MARLIM_LIBGOMP_STATIC}" REALPATH)
+    get_filename_component(MARLIM_GCC_RUNTIME_DIR "${MARLIM_LIBGOMP_STATIC_REAL}" DIRECTORY)
+    execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" -dumpmachine
+        OUTPUT_VARIABLE MARLIM_GCC_MACHINE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    execute_process(
+        COMMAND "${CMAKE_CXX_COMPILER}" -dumpversion
+        OUTPUT_VARIABLE MARLIM_GCC_MAJOR_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    target_link_options(Marlim3 PRIVATE -static-libgcc -static-libstdc++)
+    target_link_libraries(Marlim3 PRIVATE
+        "${MARLIM_LIBGOMP_STATIC}"
+        "${MARLIM_LIBGFORTRAN_STATIC}"
+        "${MARLIM_LIBQUADMATH_STATIC}")
+    foreach(MARLIM_MACOS_RPATH IN ITEMS
+            "@loader_path"
+            "${MARLIM_GCC_RUNTIME_DIR}/gcc/${MARLIM_GCC_MACHINE}/${MARLIM_GCC_MAJOR_VERSION}"
+            "${MARLIM_GCC_RUNTIME_DIR}/gcc"
+            "${MARLIM_GCC_RUNTIME_DIR}")
+        add_custom_command(TARGET Marlim3 POST_BUILD
+            COMMAND /bin/sh -c "install_name_tool -delete_rpath '${MARLIM_MACOS_RPATH}' '$<TARGET_FILE:Marlim3>' 2>/dev/null || true"
+            VERBATIM)
+    endforeach()
 
 elseif(MARLIM_STATIC_GNU_RUNTIMES AND MINGW
         AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -138,5 +228,10 @@ set_source_files_properties(${FSRCDIR}/VLECalculations.f90   PROPERTIES OBJECT_D
 set_source_files_properties(${FSRCDIR}/PhaseProperties.f90   PROPERTIES OBJECT_DEPENDS "${FSRCDIR}/VLECalculations.f90;${FSRCDIR}/Constants.f90")
 
 set_target_properties(Marlim3 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+if(APPLE)
+    set_target_properties(Marlim3 PROPERTIES
+        SKIP_BUILD_RPATH TRUE
+        INSTALL_RPATH "")
+endif()
 
 install(TARGETS Marlim3 DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -146,12 +146,22 @@ The project uses [CMake presets](CMakePresets.json). Available presets:
 | `clang-release` / `clang-debug` | Linux / macOS | Clang 20 + GFortran portable build |
 
 Release assets are built and tested for Linux x64, Windows x64, and macOS ARM64.
+Linux, Windows, and macOS ARM64 release executables are built so end users do not need GCC runtime libraries installed.
 
-#### Linux / macOS
+#### Linux
 
 ```bash
 cmake --preset gcc-release
 cmake --build --preset gcc-release -j$(nproc)
+```
+#### MacOS - Apple
+
+On macOS, install Homebrew GCC and CMake before building locally:
+
+```bash
+brew install gcc cmake
+cmake --preset gcc-release
+cmake --build --preset gcc-release -j$(sysctl -n hw.ncpu)
 ```
 
 #### Windows (MSYS2 / MinGW64)

--- a/_version.py
+++ b/_version.py
@@ -1,3 +1,3 @@
 """Version information for Marlim3 package."""
 
-__version__ = '3.6.4'
+__version__ = '3.6.5'


### PR DESCRIPTION
## Problem - Issue #31 

The macOS ARM release binary dynamically linked libgomp, libgfortran, and libquadmath against Homebrew's GCC installation at build time, embedding Homebrew-specific RPATHs in the binary. On any machine without the exact same GCC version installed, `import marlim3` failed at runtime with:

    dyld: Library not loaded: /opt/homebrew/opt/gcc/lib/gcc/current/libgomp.1.dylib

## Solution

Statically link all GNU runtime libraries (libgomp.a, libgfortran.a, libquadmath.a) during the macOS ARM build and strip all Homebrew RPATHs post-build via install_name_tool. The released binary now depends only on /usr/lib/libSystem.B.dylib.

To eliminate manual compiler setup, CMakeLists.txt resolves the versioned Homebrew GCC (g++-16…g++-12) automatically before project() initialises the toolchain, so `cmake --preset gcc-release` works on macOS without environment variables or -DCMAKE_CXX_COMPILER overrides.

## Changes

- CMakeLists.txt: add MARLIM_MACOS_STATIC_RUNTIMES build path; locate static GNU runtime libraries via gcc -print-file-name; strip Homebrew RPATHs post-build; add pre-project() find_program block for macOS compiler resolution; guard against accidental AppleClang use
- .github/workflows/build-test-release.yml: remove manual GCC version detection from macOS build step; assert absence of Homebrew/GNU runtime references in the produced binary via otool and grep
- README.md: separate macOS build instructions from Linux; document brew install gcc as the only build-time prerequisite
-  Bump package/release version to `3.6.5`.

## Testing

- Validated locally on macOS ARM64
- otool -L shows only /usr/lib/libSystem.B.dylib
- ./Marlim3 --help exits successfully

Fixes issue: https://github.com/petrobras/marlim3/issues/31
