### PR TITLE
fix: include translations.json in package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include _version.py
 include tutoriais/*.json
 include marlim3/Marlim3
 include marlim3/Marlim3.exe
+include marlim3/translations.json

--- a/_version.py
+++ b/_version.py
@@ -1,3 +1,3 @@
 """Version information for Marlim3 package."""
 
-__version__ = '3.7.0'
+__version__ = '3.7.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ Homepage = "https://github.com/petrobras/marlim3"
 [tool.setuptools.packages.find]
 include = ["marlim3", "marlim3.*"]
 
+[tool.setuptools.package-data]
+marlim3 = ["translations.json"]
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Development dependencies  (uv dependency groups — not shipped to end users)
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The translations.json file was missing from the built wheel, causing a FileNotFoundError on first import in fresh installs.