### PR TITLE
ci: build desktop applications only for tagged releases

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -469,6 +469,7 @@ jobs:
     name: Desktop App – Linux x64
     runs-on: ubuntu-24.04
     needs: test-linux
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Checkout
@@ -548,6 +549,7 @@ jobs:
     name: Desktop App – Windows x64
     runs-on: windows-2022
     needs: test-windows
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Checkout
@@ -609,6 +611,7 @@ jobs:
     name: Desktop App – macOS ARM64
     runs-on: macos-15
     needs: test-macos
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The desktop application build jobs (`desktop-linux`, `desktop-windows`, `desktop-macos`) previously ran on every pull request and every push to `develop`, even though the resulting executables are only consumed by the `release` job on tag pushes. This wasted CI minutes and runner time on long-running Qt/WebEngine desktop builds that were ultimately discarded.

This change gates the three desktop build jobs behind `if: startsWith(github.ref, 'refs/tags/v')`, so desktop executables are produced only during the release workflow (i.e. when triggered by a `v*` tag push). All other events (pull requests and `develop` pushes) continue to run the engine build and test jobs unchanged, simply skipping the desktop packaging step.

## Behavior

| Event | Desktop jobs |
|-----------------------------|:------------:|
| Pull request (develop/main) | skipped |
| Push to `develop` | skipped |
| Tag push (`v*`, release) | run |


## Testing

- Verified workflow YAML remains syntactically valid.
- Confirmed the desktop jobs' `if` condition matches the existing `release` job condition, ensuring the `needs` chain stays intact on tag pushes.