### PR TITLE
Compile as C++20 and build the Linux engine on manylinux_2_28

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -88,7 +88,7 @@ jobs:
 
   # Build jobs: produce the native executable only. No tests here.
   build-linux:
-    name: Build – Linux x64 (manylinux2014)
+    name: Build – Linux x64 (manylinux_2_28)
     needs:
       - pre_check
       - python-checks
@@ -101,19 +101,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build executable in manylinux2014
+      - name: Build executable in manylinux_2_28
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
-            quay.io/pypa/manylinux2014_x86_64 \
+            quay.io/pypa/manylinux_2_28_x86_64 \
             bash -lc '
               set -euo pipefail
-              # devtoolset-10/enable references MANPATH/LD_LIBRARY_PATH, which
-              # are unset in the clean manylinux container; pre-initialize them
-              # so `set -u` does not abort on the unbound variable.
-              export MANPATH="${MANPATH:-}"
-              export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
-              source /opt/rh/devtoolset-10/enable
+              # Unlike manylinux2014, this image ships GCC 14 as the default
+              # toolchain, so no devtoolset activation is required.
               /opt/python/cp312-cp312/bin/python -m pip install "cmake>=3.27,<4"
               export PATH="/opt/python/cp312-cp312/bin:${PATH}"
               cd /workspace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(MARLIM_MINGW_STATIC "Build a fully static executable with MinGW" ON)
 set(MARLIM_FORTRAN_LIBS "" CACHE STRING "Additional Fortran runtime libraries to link explicitly")
 set(MARLIM_GCC_STATIC_LIB_DIR "" CACHE PATH "Directory containing static GNU runtime libraries for macOS builds")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ Compilation is only necessary if you need to rebuild the executable from source.
 
 ### Requirements
 
-- GCC/G++ >= 9.0
-- GFortran >= 9.0
+- GCC/G++ >= 10.0 (the sources are built as C++20)
+- GFortran >= 10.0
 - CMake >= 3.16
 
 ### Build the executable


### PR DESCRIPTION
## Summary

Updates the C++ codebase from C++11 to C++20 and moves the Linux engine build from `manylinux2014` to `manylinux_2_28`, using GCC 14 with full C++20 support. This also removes the previous `devtoolset` setup and related environment initialization.

## Changes

* `ci`: migrate the Linux engine build to `manylinux_2_28` with GCC 14.
* `build`: set `CMAKE_CXX_STANDARD` to 20.
* `docs`: update the documented minimum compiler from GCC 9 to GCC 10.


## Compatibility

The engine's minimum glibc requirement increases from 2.17 to 2.26, remaining below the existing glibc 2.34 baseline for Linux artifacts. `manylinux_2_34` was evaluated but rejected because it produces a binary requiring `GLIBC_2.35`. The desktop build remains unchanged.

## Notes

The heaviest transient model build improves from approximately **103s to 53s**. 

> This PR only updates the language standard and toolchain, code modernization remains out of scope.
