### PR TITLE
Align parser input keys with the documented schema

### DIFF
--- a/demos/injec-Liq-ResidenceTime.mr3
+++ b/demos/injec-Liq-ResidenceTime.mr3
@@ -207,7 +207,7 @@
                                "temp2":  40.0,
                                "visc2":  0.8,
                                "salinity":  0.0,
-                               "fluidType":  2
+                               "complementaryFluidType":  2
                            },
     "gasFluid":  {
                      "id":  0,
@@ -1519,7 +1519,7 @@
                               "api":  true,
                               "bsw":  true,
                               "internalReynolds":  true,
-                              "tempoResiLiqComp":  true,
+                              "residenceTime":  true,
                               "frictionReducer":  true,
                               "time":  [
                                                    0,

--- a/demos/pt-br/injec-Liq-TempoResidencia.mr3
+++ b/demos/pt-br/injec-Liq-TempoResidencia.mr3
@@ -92,7 +92,7 @@
       "fracCO2": 0.0,"correlacaoCritica": 1}
   ],
   "fluidoComplementar": {"id": 0,"massaEspecifica": 1000,"compP": 0.0,"compT": 0.0,"tensup": 0.000001 ,"calorEspecifico": 4000.0,"condutividade": 0.14,"temp1": 20.0,
-    "visc1": 1.0,"temp2": 40.0,"visc2": 0.8,"salinidade" : 0.0, "tipoFluido":2},
+    "visc1": 1.0,"temp2": 40.0,"visc2": 0.8,"salinidade" : 0.0, "tipoF":2},
   "fluidoGas": {"id": 0,"densidadeGas": 0.55, "fracCO2": 0.0,"correlacaoCritica": 0},
   "material":[
    {"id":0,"rotulo":"aco1","condutividade":55.0,"calorEspecifico":465.0,"rho":7833.0,"tipo":0,"visc":0.0},
@@ -505,7 +505,7 @@
     "api": true,
     "bsw": true,
     "ReyInterno":true,
-    "tempoResiLiqComp":true,
+    "TResi":true,
     "RedutorAtrito":true,
     "tempo": [0 , 1000 , 7000 , 7100 , 7500 , 8000 , 10000 , 15000 , 20000 , 30000 ,  30500 , 31000 , 32500 , 33000 , 33500 , 34000 , 34500 , 35000 , 35500 , 36000 ,
           37000 , 38000 , 39000 , 40000 , 41000 , 42000 , 43000 , 44000 , 45000 , 47000 , 50000]

--- a/docs/dev-guide/fluid-thermodynamics.md
+++ b/docs/dev-guide/fluid-thermodynamics.md
@@ -631,7 +631,7 @@ Each cell stores one `ProFluCol` object as `fluicol`.
 | Viscosity | Arrhenius: $\mu_w = 2.414 \times 10^{-5} \cdot 10^{247.8/(T + 133.15)} \times 1000$ (cP) |
 | Cp | Polynomial in $T_K$, piecewise at 410 K |
 | Conductivity | $k = 0.565 + (1.75 \times 10^{-3} - 6.21 \times 10^{-6} T) T$ |
-| Surface tension | Fixed reference value: $0.0728\ \mathrm{N/m}$ (pure water at $20\,^\circ\mathrm{C}$) |
+| Surface tension | Defaults to $0.072\ \mathrm{N/m}$ at $25\,^\circ\mathrm{C}$ and can be overridden with `fluidoComplementar.tensup` |
 
 ### CO₂ injection mode (`injPoc == 3`)
 

--- a/docs/dev-guide/fluid-thermodynamics.md
+++ b/docs/dev-guide/fluid-thermodynamics.md
@@ -631,6 +631,7 @@ Each cell stores one `ProFluCol` object as `fluicol`.
 | Viscosity | Arrhenius: $\mu_w = 2.414 \times 10^{-5} \cdot 10^{247.8/(T + 133.15)} \times 1000$ (cP) |
 | Cp | Polynomial in $T_K$, piecewise at 410 K |
 | Conductivity | $k = 0.565 + (1.75 \times 10^{-3} - 6.21 \times 10^{-6} T) T$ |
+| Surface tension | Fixed reference value: $0.0728\ \mathrm{N/m}$ (pure water at $20\,^\circ\mathrm{C}$) |
 
 ### CO₂ injection mode (`injPoc == 3`)
 

--- a/docs/dev-guide/input-parsing.md
+++ b/docs/dev-guide/input-parsing.md
@@ -126,6 +126,20 @@ void JSONObject::load(Value& v) {
 
 Each `JSONInstance` subclass tracks whether its value was present in the JSON via the `bIsNull` flag (set `false` after a successful `load()`), accessible through the `exists()` method.
 
+!!! warning "Key names are matched exactly"
+    Because lookup is a plain `HasMember` test, a key whose name does not match
+    the one registered in `contents` is not loaded at all: `exists()` stays
+    `false` and the field silently keeps its default. Renaming a key in
+    `JSON_entrada.cpp` is therefore a breaking change for existing input files,
+    even though nothing fails at parse time.
+
+    To keep that failure mode visible, `validaTipoJson.cpp` rejects the known
+    discontinued spellings with an explicit validation error before the typed
+    schema is populated. The list lives in `valida_chaves_descontinuadas()` and
+    is mirrored in the
+    [input migration guide](../single-branch-model-reference/migration.md).
+    Any future rename must be added to both.
+
 ---
 
 <a id="layer-2--json_entrada-typed-schema-classes"></a>

--- a/docs/schemas/branch.en.json
+++ b/docs/schemas/branch.en.json
@@ -2822,6 +2822,7 @@
             2,
             3
           ],
+          "default": 0,
           "description": "0: user-provided fluid (liquid) from complementaryFluid; 1: water (requires salinity); 2: CO2-rich gas via flash table (.tab Pvtsim file and production-fluid registration required); 3: CO2-rich gas via compositional model (.ctm Pvtsim file and production-fluid registration required)."
         },
         "salinity": {

--- a/docs/schemas/branch.en.json
+++ b/docs/schemas/branch.en.json
@@ -1028,7 +1028,8 @@
         "surfaceTension": {
           "type": "number",
           "description": "Liquid surface tension.",
-          "unit": "N/m"
+          "unit": "N/m",
+          "default": 0.072
         },
         "specificHeat": {
           "type": "number",

--- a/docs/schemas/branch.pt.json
+++ b/docs/schemas/branch.pt.json
@@ -1045,7 +1045,8 @@
         "tensup": {
           "type": "number",
           "description": "Tensão superficial do líquido.",
-          "unit": "N/m"
+          "unit": "N/m",
+          "default": 0.072
         },
         "calorEspecifico": {
           "type": "number",

--- a/docs/schemas/branch.pt.json
+++ b/docs/schemas/branch.pt.json
@@ -2877,6 +2877,7 @@
             2,
             3
           ],
+          "default": 0,
           "description": "0: fluido (líquido) dado pelo usuário (informado no campo fluidoComplementar); 1: água (é preciso informar a salinidade); 2: gás rico em CO2 via tabela flash (arquivo Pvtsim .tab requerido, cadastro de fluido de produção requerido; 3: gás rico em CO2 via composicional (arquivo Pvtsim .ctm requerido, cadastro de fluido de produção requerido)."
         },
         "salinidade": {

--- a/docs/single-branch-model-reference/accessories.md
+++ b/docs/single-branch-model-reference/accessories.md
@@ -127,7 +127,7 @@ Fluid definition:
   - `1` = external hydrocarbon assumed equal to current tubing fluid
   - `0` = external fluid explicitly defined by `prodFluidId`
 - `prodFluidId` · `indiFluidoPro`
-- `gasAmbient` · `ambienteGas` — admit only gaseous fraction of external fluid
+- `gasAmbient` · `ambGas` — admit only gaseous fraction of external fluid
 
 Flow-direction control:
 

--- a/docs/single-branch-model-reference/fluids.md
+++ b/docs/single-branch-model-reference/fluids.md
@@ -352,9 +352,14 @@ For the generic type, the following properties define the fluid:
 - **Conductivity** [W/(m·K)] *(key: `conductivity` / `condutividade`)*
 - **Viscosity** via two ASTM points *(keys: `temp1`, `visc1`, `temp2`, `visc2`)*
 
-For water-based type, provide only:
+For water-based type, the only required property is:
 
 - **Salinity** [g/(kg water)] *(key: `salinity` / `salinidade`)*
+
+All remaining properties come from internal water correlations. Surface tension
+is the one value that may still be overridden: when `surfaceTension` / `tensup`
+is omitted the engine assumes `0.072 N/m` (water at about 25 °C), and any value
+supplied by the user takes precedence.
 
 ---
 

--- a/docs/single-branch-model-reference/migration.md
+++ b/docs/single-branch-model-reference/migration.md
@@ -1,0 +1,57 @@
+# Input Migration Guide
+
+The engine resolves every input field by exact key name. A key that does not
+match the schema is not applied, so a renamed field would silently fall back to
+its default value and change simulation results without any warning.
+
+To make that impossible, the discontinued spellings listed below are now
+rejected with an explicit validation error. Update the affected keys in your
+`.mr3` files and the model runs unchanged.
+
+## Discontinued input keys
+
+The engine now reads exactly the names published in the
+[JSON schema](json-schema.md), which are also the names produced by the
+`marlim3` Python API. If you build models through the Python API, no change is
+required — files it generates already use the current names.
+
+| Object | Discontinued key | Use instead |
+|---|---|---|
+| `fluidoComplementar` | `tipoFluido` | `tipoF` |
+| `configuracaoInicial` | `modoDifus3DArq` | `modoDifus3DJson` |
+| `configuracaoInicial.condicaoVazPres` | `Vazao Massica` | `VazMass` |
+| `dutosProducao[]` | `difusTerm3DRotulo` | `difusTerm3DAcop` |
+| `parafina` | `multiplicadorViscosidade` | `multVis` |
+| `fontePressao[]` | `ambienteGas` | `ambGas` |
+| `tendP[]` | `tempChokeJusante` | `tempChokeJus` |
+| `perfilProducao` | `tempoResiLiqComp` | `TResi` |
+| root | `poroRadial` | `fontePoroRadial` |
+| root | `poro2D` | `fontePoro2D` |
+
+English-language files are translated to the internal Portuguese names before
+validation, so the same rules apply to their English equivalents — for example
+`complementaryFluidType` for `tipoF` and `residenceTime` for `TResi`.
+
+## Error message
+
+A discontinued key aborts the run during input validation with a message that
+names the replacement:
+
+```text
+#/fluidoComplementar/tipoFluido: chave descontinuada, utilize 'tipoF'
+```
+
+## Why the keys were not simply accepted as aliases
+
+Keeping both spellings would let two different names address the same field,
+which makes input files ambiguous and hides the divergence between the engine
+and the published schema. Rejecting the old spelling surfaces the problem at
+validation time, when it can still be corrected, instead of producing a result
+that looks valid but was computed with a default value.
+
+## Impact if a key is left unchanged
+
+Before this change the field was ignored. Depending on the key, that could
+disable a whole model feature — for example, `fluidoComplementar.tipoFluido = 2`
+selects the friction-reducer fluid, so losing it removes the friction reduction
+from the pressure solution and shifts the reported profiles.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - General: single-branch-model-reference/general.md
     - Results: single-branch-model-reference/results.md
     - JSON Schema: single-branch-model-reference/json-schema.md
+    - Input Migration: single-branch-model-reference/migration.md
   - Theory:
     - Overview: theoretical-reference/index.md
     - Drift-Flux vs. Two-Fluid: theoretical-reference/two-fluids_vs_drift-flux.md

--- a/src/core/JSON_entrada.cpp
+++ b/src/core/JSON_entrada.cpp
@@ -383,7 +383,7 @@ JSON_entrada_configuracaoInicial::JSON_entrada_configuracaoInicial(){
 	contents["tipoModeloDrift"] = make_shared<JSON_entrada_configuracaoInicial_tipoModeloDrift>();
 	contents["modoDifus3D"] = make_shared<JSON_entrada_configuracaoInicial_modoDifus3D>();
 	contents["threadP3D"] = make_shared<JSON_entrada_configuracaoInicial_threadP3D>();
-	contents["modoDifus3DArq"] = make_shared<JSON_entrada_configuracaoInicial_modoDifus3DJson>();
+	contents["modoDifus3DJson"] = make_shared<JSON_entrada_configuracaoInicial_modoDifus3DJson>();
 }
 
 JSON_entrada_configuracaoInicial_origemGeometria& JSON_entrada_configuracaoInicial::origemGeometria(){
@@ -624,7 +624,7 @@ JSON_entrada_configuracaoInicial_threadP3D& JSON_entrada_configuracaoInicial::th
 }
 
 JSON_entrada_configuracaoInicial_modoDifus3DJson& JSON_entrada_configuracaoInicial::modoDifus3DJson(){
-	return static_cast<JSON_entrada_configuracaoInicial_modoDifus3DJson&>(*contents["modoDifus3DArq"].get());
+	return static_cast<JSON_entrada_configuracaoInicial_modoDifus3DJson&>(*contents["modoDifus3DJson"].get());
 }
 
 
@@ -673,7 +673,7 @@ JSON_entrada_parafina::JSON_entrada_parafina(){
 	contents["alteraViscFlu"] = make_shared<JSON_entrada_parafina_alteraViscFlu>();
 	contents["difus"] = make_shared<JSON_entrada_parafina_difus>();
 	contents["rugosidade"] = make_shared<JSON_entrada_parafina_rugosidade>();
-	contents["multiplicadorViscosidade"] = make_shared<JSON_entrada_parafina_multVis>();
+	contents["multVis"] = make_shared<JSON_entrada_parafina_multVis>();
 	contents["DmultipWax"] = make_shared<JSON_entrada_parafina_DmultipWax>();
 	contents["EmultipWax"] = make_shared<JSON_entrada_parafina_EmultipWax>();
 	contents["FmultipWax"] = make_shared<JSON_entrada_parafina_FmultipWax>();
@@ -721,7 +721,7 @@ JSON_entrada_parafina_rugosidade& JSON_entrada_parafina::rugosidade(){
 }
 
 JSON_entrada_parafina_multVis& JSON_entrada_parafina::multVis(){
-	return static_cast<JSON_entrada_parafina_multVis&>(*contents["multiplicadorViscosidade"].get());
+	return static_cast<JSON_entrada_parafina_multVis&>(*contents["multVis"].get());
 }
 
 JSON_entrada_parafina_DmultipWax& JSON_entrada_parafina::DmultipWax(){
@@ -857,7 +857,7 @@ JSON_entrada_fluidosProducao_Item_bswCorte& JSON_entrada_fluidosProducao_Item::b
 	return static_cast<JSON_entrada_fluidosProducao_Item_bswCorte&>(*contents["bswCorte"].get());
 }
 
-JSON_entrada_fluidosProducao_Item_coefAModeloExp& JSON_entrada_fluidosProducao_Item::PHI100(){
+JSON_entrada_fluidosProducao_Item_PHI100& JSON_entrada_fluidosProducao_Item::PHI100(){
 	return static_cast<JSON_entrada_fluidosProducao_Item_PHI100&>(*contents["PHI100"].get());
 }
 
@@ -1648,7 +1648,7 @@ JSON_entrada_dutosProducao_Item::JSON_entrada_dutosProducao_Item(){
 	contents["difusTerm2DJSON"] = make_shared<JSON_entrada_dutosProducao_Item_difusTerm2DJSON>();
 	contents["difusTerm3D"] = make_shared<JSON_entrada_dutosProducao_Item_difusTerm3D>();
 	contents["difusTerm3DFE"] = make_shared<JSON_entrada_dutosProducao_Item_difusTerm3DFE>();
-	contents["difusTerm3DRotulo"] = make_shared<JSON_entrada_dutosProducao_Item_difusTerm3DAcop>();
+	contents["difusTerm3DAcop"] = make_shared<JSON_entrada_dutosProducao_Item_difusTerm3DAcop>();
 	contents["xCoor"] = make_shared<JSON_entrada_dutosProducao_Item_xCoor>();
 	contents["yCoor"] = make_shared<JSON_entrada_dutosProducao_Item_yCoor>();
 	contents["nCelulas_XY"] = make_shared<JSON_entrada_dutosProducao_Item_nCelulas_XY>();
@@ -1768,7 +1768,7 @@ JSON_entrada_dutosProducao_Item_difusTerm3DFE& JSON_entrada_dutosProducao_Item::
 }
 
 JSON_entrada_dutosProducao_Item_difusTerm3DAcop& JSON_entrada_dutosProducao_Item::difusTerm3DAcop(){
-	return static_cast<JSON_entrada_dutosProducao_Item_difusTerm3DAcop&>(*contents["difusTerm3DRotulo"].get());
+	return static_cast<JSON_entrada_dutosProducao_Item_difusTerm3DAcop&>(*contents["difusTerm3DAcop"].get());
 }
 
 JSON_entrada_dutosServico_Item_condicoesIniciais::JSON_entrada_dutosServico_Item_condicoesIniciais(){
@@ -1949,7 +1949,7 @@ JSON_entrada_dutosServico_Item_condicoesIniciais& JSON_entrada_dutosServico_Item
 }
 
 JSON_entrada_dutosServico_Item_condicoesIniciaisEAmbiente& JSON_entrada_dutosServico_Item::condicoesIniciaisEAmbiente(){
-	return static_cast<JSON_entrada_dutosServico_Item_condicoesIniciaisEAmbiente&>(*contents["condicoesIniciais"].get());
+	return static_cast<JSON_entrada_dutosServico_Item_condicoesIniciaisEAmbiente&>(*contents["condicoesIniciaisEAmbiente"].get());
 }
 
 JSON_entrada_dutosServico_Item_dPdLHidro& JSON_entrada_dutosServico_Item::dPdLHidro(){
@@ -2142,7 +2142,7 @@ JSON_entrada_ipr_Item_comprimentoMedido& JSON_entrada_ipr_Item::comprimentoMedid
 	return static_cast<JSON_entrada_ipr_Item_comprimentoMedido&>(*contents["comprimentoMedido"].get());
 }
 
-JSON_entrada_ipr_Item_id& JSON_entrada_ipr_Item::tipoIPR(){
+JSON_entrada_ipr_Item_tipoIPR& JSON_entrada_ipr_Item::tipoIPR(){
 	return static_cast<JSON_entrada_ipr_Item_tipoIPR&>(*contents["tipoIPR"].get());
 }
 

--- a/src/core/JSON_entrada.cpp
+++ b/src/core/JSON_entrada.cpp
@@ -2646,7 +2646,7 @@ JSON_entrada_fontePressao_Item::JSON_entrada_fontePressao_Item(){
 	contents["indiFluidoPro"] = make_shared<JSON_entrada_fontePressao_Item_indiFluidoPro>();
 	contents["check"] = make_shared<JSON_entrada_fontePressao_Item_check>();
 	contents["tempoChk"] = make_shared<JSON_entrada_fontePressao_Item_tempoChk>();
-	contents["ambienteGas"] = make_shared<JSON_entrada_fontePressao_Item_ambGas>();
+	contents["ambGas"] = make_shared<JSON_entrada_fontePressao_Item_ambGas>();
 }
 
 JSON_entrada_fontePressao_Item_ativo& JSON_entrada_fontePressao_Item::ativo(){
@@ -2710,7 +2710,7 @@ JSON_entrada_fontePressao_Item_tempoChk& JSON_entrada_fontePressao_Item::tempoCh
 }
 
 JSON_entrada_fontePressao_Item_ambGas& JSON_entrada_fontePressao_Item::ambGas(){
-	return static_cast<JSON_entrada_fontePressao_Item_ambGas&>(*contents["ambienteGas"].get());
+	return static_cast<JSON_entrada_fontePressao_Item_ambGas&>(*contents["ambGas"].get());
 }
 
 JSON_entrada_tendP_Item::JSON_entrada_tendP_Item(){
@@ -2770,7 +2770,7 @@ JSON_entrada_tendP_Item::JSON_entrada_tendP_Item(){
 	contents["mlFonte"] = make_shared<JSON_entrada_tendP_Item_mlFonte>();
 	contents["mgFonte"] = make_shared<JSON_entrada_tendP_Item_mgFonte>();
 	contents["mcFonte"] = make_shared<JSON_entrada_tendP_Item_mcFonte>();
-	contents["tempChokeJusante"] = make_shared<JSON_entrada_tendP_Item_tempChokeJus>();
+	contents["tempChokeJus"] = make_shared<JSON_entrada_tendP_Item_tempChokeJus>();
 	contents["deltaPBomba"] = make_shared<JSON_entrada_tendP_Item_deltaPBomba>();
 	contents["potenciaBomba"] = make_shared<JSON_entrada_tendP_Item_potenciaBomba>();
 
@@ -3017,7 +3017,7 @@ JSON_entrada_tendP_Item_mcFonte& JSON_entrada_tendP_Item::mcFonte(){
 }
 
 JSON_entrada_tendP_Item_tempChokeJus& JSON_entrada_tendP_Item::tempChokeJus(){
-	return static_cast<JSON_entrada_tendP_Item_tempChokeJus&>(*contents["tempChokeJusante"].get());
+	return static_cast<JSON_entrada_tendP_Item_tempChokeJus&>(*contents["tempChokeJus"].get());
 }
 
 JSON_entrada_tendP_Item_deltaPBomba& JSON_entrada_tendP_Item::deltaPBomba(){
@@ -3462,7 +3462,7 @@ JSON_entrada_perfilProducao::JSON_entrada_perfilProducao(){
 	contents["pseudoLiquido"] = make_shared<JSON_entrada_perfilProducao_pseudoLiquido>();
 	contents["pseudoGas"] = make_shared<JSON_entrada_perfilProducao_pseudoGas>();
 	contents["pseudoMist"] = make_shared<JSON_entrada_perfilProducao_pseudoMist>();
-	contents["tempoResiLiqComp"] = make_shared<JSON_entrada_perfilProducao_TResi>();
+	contents["TResi"] = make_shared<JSON_entrada_perfilProducao_TResi>();
 	contents["RedutorAtrito"] = make_shared<JSON_entrada_perfilProducao_RedutorAtrito>();
 	contents["angulo"] = make_shared<JSON_entrada_perfilProducao_angulo>();
 	contents["diametroInterno"] = make_shared<JSON_entrada_perfilProducao_diametroInterno>();
@@ -3735,7 +3735,7 @@ JSON_entrada_perfilProducao_pseudoMist& JSON_entrada_perfilProducao::pseudoMist(
 }
 
 JSON_entrada_perfilProducao_TResi& JSON_entrada_perfilProducao::TResi(){
-	return static_cast<JSON_entrada_perfilProducao_TResi&>(*contents["tempoResiLiqComp"].get());
+	return static_cast<JSON_entrada_perfilProducao_TResi&>(*contents["TResi"].get());
 }
 
 JSON_entrada_perfilProducao_RedutorAtrito& JSON_entrada_perfilProducao::RedutorAtrito(){
@@ -4198,8 +4198,8 @@ JSON_entrada::JSON_entrada(){
 	contents["fonteLiquido"] = make_shared<JSON_entrada_fonteLiquido>();
 	contents["fonteMassa"] = make_shared<JSON_entrada_fonteMassa>();
 	contents["fonteGas"] = make_shared<JSON_entrada_fonteGas>();
-	contents["poroRadial"] = make_shared<JSON_entrada_fontePoroRadial>();
-	contents["poro2D"] = make_shared<JSON_entrada_fontePoro2D>();
+	contents["fontePoroRadial"] = make_shared<JSON_entrada_fontePoroRadial>();
+	contents["fontePoro2D"] = make_shared<JSON_entrada_fontePoro2D>();
 	contents["fonteGasLift"] = make_shared<JSON_entrada_fonteGasLift>();
 	contents["material"] = make_shared<JSON_entrada_material>();
 	contents["secaoTransversal"] = make_shared<JSON_entrada_secaoTransversal>();
@@ -4286,11 +4286,11 @@ JSON_entrada_fonteGas& JSON_entrada::fonteGas(){
 }
 
 JSON_entrada_fontePoroRadial& JSON_entrada::fontePoroRadial(){
-	return static_cast<JSON_entrada_fontePoroRadial&>(*contents["poroRadial"].get());
+	return static_cast<JSON_entrada_fontePoroRadial&>(*contents["fontePoroRadial"].get());
 }
 
 JSON_entrada_fontePoro2D& JSON_entrada::fontePoro2D(){
-	return static_cast<JSON_entrada_fontePoro2D&>(*contents["poro2D"].get());
+	return static_cast<JSON_entrada_fontePoro2D&>(*contents["fontePoro2D"].get());
 }
 
 JSON_entrada_fonteGasLift& JSON_entrada::fonteGasLift(){

--- a/src/core/JSON_entrada.cpp
+++ b/src/core/JSON_entrada.cpp
@@ -202,7 +202,7 @@ JSON_entrada_configuracaoInicial_condicaoVazPres::JSON_entrada_configuracaoInici
 	contents["ativo"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_ativo>();
 	contents["pressao"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_pressao>();
 	contents["temperatura"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_temperatura>();
-	contents["Vazao Massica"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_VazMass>();
+	contents["VazMass"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_VazMass>();
 	contents["razaoBeta"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_razaoBeta>();
 	contents["tempo"] = make_shared<JSON_entrada_configuracaoInicial_condicaoVazPres_tempo>();
 }
@@ -220,7 +220,7 @@ JSON_entrada_configuracaoInicial_condicaoVazPres_temperatura& JSON_entrada_confi
 }
 
 JSON_entrada_configuracaoInicial_condicaoVazPres_VazMass& JSON_entrada_configuracaoInicial_condicaoVazPres::VazMass(){
-	return static_cast<JSON_entrada_configuracaoInicial_condicaoVazPres_VazMass&>(*contents["Vazao Massica"].get());
+	return static_cast<JSON_entrada_configuracaoInicial_condicaoVazPres_VazMass&>(*contents["VazMass"].get());
 }
 
 JSON_entrada_configuracaoInicial_condicaoVazPres_razaoBeta& JSON_entrada_configuracaoInicial_condicaoVazPres::razaoBeta(){

--- a/src/core/JSON_entrada.cpp
+++ b/src/core/JSON_entrada.cpp
@@ -950,7 +950,7 @@ JSON_entrada_fluidoComplementar::JSON_entrada_fluidoComplementar(){
 	contents["temp2"] = make_shared<JSON_entrada_fluidoComplementar_temp2>();
 	contents["visc2"] = make_shared<JSON_entrada_fluidoComplementar_visc2>();
 	contents["salinidade"] = make_shared<JSON_entrada_fluidoComplementar_salinidade>();
-	contents["tipoFluido"] = make_shared<JSON_entrada_fluidoComplementar_tipoF>();
+	contents["tipoF"] = make_shared<JSON_entrada_fluidoComplementar_tipoF>();
 }
 
 JSON_entrada_fluidoComplementar_ativo& JSON_entrada_fluidoComplementar::ativo(){
@@ -1002,7 +1002,7 @@ JSON_entrada_fluidoComplementar_salinidade& JSON_entrada_fluidoComplementar::sal
 }
 
 JSON_entrada_fluidoComplementar_tipoF& JSON_entrada_fluidoComplementar::tipoF(){
-	return static_cast<JSON_entrada_fluidoComplementar_tipoF&>(*contents["tipoFluido"].get());
+	return static_cast<JSON_entrada_fluidoComplementar_tipoF&>(*contents["tipoF"].get());
 }
 
 JSON_entrada_valvula_Item::JSON_entrada_valvula_Item(){

--- a/src/core/Leitura.cpp
+++ b/src/core/Leitura.cpp
@@ -4685,8 +4685,11 @@ void Ler::parse_fluido_complementar(
 		double temph = 0.;
 		double lvish = 0.;
 		double sal = 0.;
-		if (tipoflui == 1)
-			tensup = 0.0728;
+		if (tipoflui == 1) {
+			tensup = 0.072;
+			if (fluido_complementar_json.tensup().exists())
+				tensup = fluido_complementar_json.tensup();
+		}
 		if(tipoflui!=1){
 			masesp =
 				fluido_complementar_json.massaEspecifica();
@@ -21518,4 +21521,3 @@ void Ler::copia_tela(Ler& arqAntigo) {
 		}
 	}
 }
-

--- a/src/core/Leitura.cpp
+++ b/src/core/Leitura.cpp
@@ -4685,6 +4685,8 @@ void Ler::parse_fluido_complementar(
 		double temph = 0.;
 		double lvish = 0.;
 		double sal = 0.;
+		if (tipoflui == 1)
+			tensup = 0.0728;
 		if(tipoflui!=1){
 			masesp =
 				fluido_complementar_json.massaEspecifica();

--- a/src/core/validaTipoJson.cpp
+++ b/src/core/validaTipoJson.cpp
@@ -5749,9 +5749,124 @@ void validadorTipo::valida_tendencia_servico(Value &tendS_json, std::vector<std:
     }
 }
 
+namespace {
+
+/*!
+ * Grafia de entrada descontinuada e a chave que deve substitui-la.
+ *
+ * Mantida em sincronia com docs/single-branch-model-reference/migration.md.
+ */
+struct ChaveDescontinuada {
+    const char *antiga;
+    const char *nova;
+};
+
+/*!
+ * Registrar erro para cada grafia descontinuada presente no objeto.
+ */
+void checar_objeto(Value &obj, const std::string &caminho,
+                   const ChaveDescontinuada *lista, int n,
+                   std::vector<std::string> &erros, bool &sucesso) {
+    if (!obj.IsObject())
+        return;
+    for (int i = 0; i < n; i++) {
+        if (obj.HasMember(lista[i].antiga)) {
+            sucesso = false;
+            erros.push_back(caminho + "/" + lista[i].antiga +
+                            ": chave descontinuada, utilize '" + lista[i].nova + "'");
+        }
+    }
+}
+
+/*!
+ * Aplicar a checagem a cada item de um array.
+ */
+void checar_array(Value &arr, const std::string &caminho,
+                  const ChaveDescontinuada *lista, int n,
+                  std::vector<std::string> &erros, bool &sucesso) {
+    if (!arr.IsArray())
+        return;
+    int nele = arr.Size();
+    for (int i = 0; i < nele; i++)
+        checar_objeto(arr[i], caminho + "/" + std::to_string(i), lista, n, erros,
+                      sucesso);
+}
+
+/*!
+ * Rejeitar grafias de entrada descontinuadas com erro explicito.
+ *
+ * O parser resolve as chaves por HasMember, de modo que uma grafia antiga
+ * seria simplesmente ignorada e o campo assumiria o valor padrao sem qualquer
+ * aviso. A checagem abaixo torna essa situacao um erro de validacao.
+ */
+void valida_chaves_descontinuadas(Document &jsonDoc,
+                                  std::vector<std::string> &erros, bool &sucesso) {
+    static const ChaveDescontinuada raiz[] = {
+        {"poroRadial", "fontePoroRadial"},
+        {"poro2D", "fontePoro2D"},
+    };
+    static const ChaveDescontinuada configuracaoInicial[] = {
+        {"modoDifus3DArq", "modoDifus3DJson"},
+    };
+    static const ChaveDescontinuada condicaoVazPres[] = {
+        {"Vazao Massica", "VazMass"},
+    };
+    static const ChaveDescontinuada fluidoComplementar[] = {
+        {"tipoFluido", "tipoF"},
+    };
+    static const ChaveDescontinuada parafina[] = {
+        {"multiplicadorViscosidade", "multVis"},
+    };
+    static const ChaveDescontinuada perfilProducao[] = {
+        {"tempoResiLiqComp", "TResi"},
+    };
+    static const ChaveDescontinuada dutosProducao[] = {
+        {"difusTerm3DRotulo", "difusTerm3DAcop"},
+    };
+    static const ChaveDescontinuada fontePressao[] = {
+        {"ambienteGas", "ambGas"},
+    };
+    static const ChaveDescontinuada tendP[] = {
+        {"tempChokeJusante", "tempChokeJus"},
+    };
+
+    checar_objeto(jsonDoc, "#", raiz, 2, erros, sucesso);
+
+    if (jsonDoc.HasMember("configuracaoInicial")) {
+        Value &ci = jsonDoc["configuracaoInicial"];
+        checar_objeto(ci, "#/configuracaoInicial", configuracaoInicial, 1, erros,
+                      sucesso);
+        if (ci.IsObject() && ci.HasMember("condicaoVazPres"))
+            checar_objeto(ci["condicaoVazPres"],
+                          "#/configuracaoInicial/condicaoVazPres", condicaoVazPres, 1,
+                          erros, sucesso);
+    }
+    if (jsonDoc.HasMember("fluidoComplementar"))
+        checar_objeto(jsonDoc["fluidoComplementar"], "#/fluidoComplementar",
+                      fluidoComplementar, 1, erros, sucesso);
+    if (jsonDoc.HasMember("parafina"))
+        checar_objeto(jsonDoc["parafina"], "#/parafina", parafina, 1, erros, sucesso);
+    if (jsonDoc.HasMember("perfilProducao"))
+        checar_objeto(jsonDoc["perfilProducao"], "#/perfilProducao", perfilProducao, 1,
+                      erros, sucesso);
+    if (jsonDoc.HasMember("dutosProducao"))
+        checar_array(jsonDoc["dutosProducao"], "#/dutosProducao", dutosProducao, 1,
+                     erros, sucesso);
+    if (jsonDoc.HasMember("fontePressao"))
+        checar_array(jsonDoc["fontePressao"], "#/fontePressao", fontePressao, 1, erros,
+                     sucesso);
+    if (jsonDoc.HasMember("tendP"))
+        checar_array(jsonDoc["tendP"], "#/tendP", tendP, 1, erros, sucesso);
+}
+
+} // namespace
+
 void validadorTipo::validaGeral(Document &jsonDoc) {
     std::vector<std::string> erros;
     bool sucesso = true;
+
+    // Rejeitar grafias de entrada descontinuadas antes das demais validacoes
+    valida_chaves_descontinuadas(jsonDoc, erros, sucesso);
 
     // Valida configuracaoInicial
     if (jsonDoc.HasMember("configuracaoInicial")) {

--- a/src/core/validaTipoJson.cpp
+++ b/src/core/validaTipoJson.cpp
@@ -1648,11 +1648,11 @@ void validadorTipo::valida_fluido_complementar(Value &fluido_complementar_json, 
         }
     }
 
-    // Validar campo tipoFluido (opcional)
-    if (fluido_complementar_json.HasMember("tipoFluido")) {
-        if (!fluido_complementar_json["tipoFluido"].IsInt()) {
+    // Validar campo tipoF (opcional)
+    if (fluido_complementar_json.HasMember("tipoF")) {
+        if (!fluido_complementar_json["tipoF"].IsInt()) {
             sucesso = false;
-            erros.push_back("fluidoComplementar/tipoFluido: deve ser do tipo inteiro");
+            erros.push_back("fluidoComplementar/tipoF: deve ser do tipo inteiro");
         }
     }
 }

--- a/src/core/validaTipoJson.cpp
+++ b/src/core/validaTipoJson.cpp
@@ -2667,11 +2667,11 @@ void validadorTipo::valida_parafina(Value &parafina_json, std::vector<std::strin
         }
     }
 
-    // Validar campo multiplicadorViscosidade (opcional)
-    if (parafina_json.HasMember("multiplicadorViscosidade")) {
-        if (!parafina_json["multiplicadorViscosidade"].IsNumber()) {
+    // Validar campo multVis (opcional)
+    if (parafina_json.HasMember("multVis")) {
+        if (!parafina_json["multVis"].IsNumber()) {
             sucesso = false;
-            erros.push_back("parafina/multiplicadorViscosidade: deve ser do tipo number");
+            erros.push_back("parafina/multVis: deve ser do tipo number");
         }
     }
 

--- a/tests/test_conversor_tplppl.py
+++ b/tests/test_conversor_tplppl.py
@@ -14,26 +14,42 @@ OUTPUT_HEADERS_PATH = REPO_ROOT / "marlim3" / "_output_headers.py"
 def _load_module_without_marlim3_init():
     """Import the converter module without triggering marlim3/__init__.py (avoids
     pulling in pandas/seaborn/the compiled simulator, which this test does not need)."""
+    saved_modules = {
+        name: sys.modules.get(name)
+        for name in (
+            "marlim3",
+            "marlim3._output_headers",
+            "marlim3._conversores",
+            "marlim3._conversores._conversor_marlim3_tplppl",
+        )
+    }
     package = types.ModuleType("marlim3")
     package.__version__ = "test"
     package.__path__ = [str(REPO_ROOT / "marlim3")]
-    sys.modules["marlim3"] = package
+    try:
+        sys.modules["marlim3"] = package
 
-    headers_spec = importlib.util.spec_from_file_location("marlim3._output_headers", OUTPUT_HEADERS_PATH)
-    headers_module = importlib.util.module_from_spec(headers_spec)
-    sys.modules["marlim3._output_headers"] = headers_module
-    headers_spec.loader.exec_module(headers_module)
+        headers_spec = importlib.util.spec_from_file_location("marlim3._output_headers", OUTPUT_HEADERS_PATH)
+        headers_module = importlib.util.module_from_spec(headers_spec)
+        sys.modules["marlim3._output_headers"] = headers_module
+        headers_spec.loader.exec_module(headers_module)
 
-    conversores_package = types.ModuleType("marlim3._conversores")
-    conversores_package.__path__ = [str(REPO_ROOT / "marlim3" / "_conversores")]
-    sys.modules["marlim3._conversores"] = conversores_package
+        conversores_package = types.ModuleType("marlim3._conversores")
+        conversores_package.__path__ = [str(REPO_ROOT / "marlim3" / "_conversores")]
+        sys.modules["marlim3._conversores"] = conversores_package
 
-    spec = importlib.util.spec_from_file_location(
-        "marlim3._conversores._conversor_marlim3_tplppl", CONVERSOR_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+        spec = importlib.util.spec_from_file_location(
+            "marlim3._conversores._conversor_marlim3_tplppl", CONVERSOR_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, previous in saved_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
 
 
 conversor = _load_module_without_marlim3_init()

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -189,3 +189,14 @@ def test_network_class_bilingual_roundtrip():
     assert net.configuracaoInicial["ParametroInicial"] == 0.5
     assert net.connection[0]["imposedPressure"] is True
 
+
+def test_complementary_water_fluid_type_key_roundtrip():
+    """Water-mode complementary fluid uses the tipoF key accepted by the engine."""
+    from marlim3._tramo._keys import translate, translate_en_to_pt
+
+    english = {"complementaryFluid": {"active": True, "complementaryFluidType": 1}}
+    portuguese = {"fluidoComplementar": {"ativo": True, "tipoF": 1}}
+
+    assert translate(portuguese) == english
+    assert translate_en_to_pt(english) == portuguese
+


### PR DESCRIPTION
The engine read several JSON keys under names that diverged from the
published schema, so those fields were silently ignored and kept their
default values. Most visibly, fluidoComplementar.tipoFluido disabled the
friction-reducer fluid, changing the pressure profile and every derived
property.

The parser now reads exactly the documented names.

BREAKING CHANGE: ten legacy spellings are no longer accepted and fail
validation with an explicit error naming the replacement. See
docs/single-branch-model-reference/migration.md.